### PR TITLE
Add validation and date formatting to insertWeight method

### DIFF
--- a/app/Http/Controllers/MobileController.php
+++ b/app/Http/Controllers/MobileController.php
@@ -1216,15 +1216,24 @@ class MobileController extends Controller
 
    public function insertWeight(Request $request)
     {
+
+    $request->validate([
+        'workout_id' => 'required|integer',
+        'member_id' => 'required|integer',
+        'weight' => 'required|numeric',
+        'selected_day' => 'required|string',
+    ]);
+    
     try {
-        $dateStr = Carbon::now()->format('d/m/y l');
+        $date = Carbon::createFromFormat('l d/m/Y', $request->selected_day);
+        $dayWithDate = $date->format('d/m/y l');
 
         $test = Test::create([
             'workout_id'  => $request->workout_id,
             'member_id'   => $request->member_id,
             'weight'      => $request->weight,
             'workoutname' => $request->workoutname,
-            'date'        => $dateStr,
+            'date'        => $dayWithDate, 
             'category_id' => $request->category_id ?? null,
         ]);
 


### PR DESCRIPTION
This pull request improves the `insertWeight` method in `MobileController` by adding input validation and updating how the date is handled when inserting a new weight record. The main changes are grouped below:

Validation improvements:

* Added validation rules to ensure that `workout_id`, `member_id`, `weight`, and `selected_day` are present and of the correct type in the request.

Date handling improvements:

* Changed the way the date is parsed and formatted by using the `selected_day` input, converting it to a `Carbon` date object, and formatting it before saving to the database.