### PR TITLE
Enhance warmup functionality and fix option values in warmup form

### DIFF
--- a/app/Http/Controllers/MobileController.php
+++ b/app/Http/Controllers/MobileController.php
@@ -1069,6 +1069,18 @@ class MobileController extends Controller
                 return $item;
             });
 
+            $detailswarmup->transform(function ($item) use ($member, $dayWithDateNew) {
+
+                $item_completed = DailyWarmup::where('member_id', $member->id)
+                    ->where('warmup_id', $item->id)
+                    ->where('reps', '>', 0)
+                    ->where('date', $dayWithDateNew)
+                    ->exists();
+
+                $item->warmup_item_completed = $item_completed ? 1 : 0;
+                return $item;
+            });
+
 
             // Append matching weight to Strength workouts
             $detailsstrength->transform(function ($item) use ($testWeights) {

--- a/resources/views/admin/components/warmup.blade.php
+++ b/resources/views/admin/components/warmup.blade.php
@@ -48,7 +48,7 @@
 
                 // AJAX request
                 $.ajax({
-                    url: '{{ route('warmups.deleteAllBySelectDate') }}',
+                    url: '{{ route("warmups.deleteAllBySelectDate") }}',
                     type: 'POST',
                     data: formData,
                     success: function(response) {
@@ -239,8 +239,8 @@
                                         <option value="Cal">Cal</option>
                                         <option value="%">%</option>
                                         <option value="Kg">Kg</option>
-                                        <option value="Kg">BW</option>
-                                        <option value="Kg">N/A</option>
+                                        <option value="BW">BW</option>
+                                        <option value="N/A">N/A</option>
                                     </select>
                                 </div>
 


### PR DESCRIPTION
This pull request introduces improvements to both backend and frontend code related to workout warmups. The main changes include tracking completion status for warmup items, correcting select option values for units, and a minor syntax update in an AJAX request.

**Backend: Warmup Completion Tracking**
- Added logic in `MobileController.php` to append a `warmup_item_completed` property to each warmup item, indicating if the member completed the warmup for the given date.

**Frontend: Warmup Options and AJAX Syntax**
- Fixed the values for "BW" (Body Weight) and "N/A" options in the warmup unit dropdown to ensure correct data is submitted.
- Updated the route definition in the AJAX request for deleting warmups to use double quotes for consistency.