### PR TITLE
Refactor getWorkouts method to streamline completion tracking and enhance type-level completion status calculation

### DIFF
--- a/app/Http/Controllers/UserMobileController.php
+++ b/app/Http/Controllers/UserMobileController.php
@@ -759,10 +759,7 @@ class UserMobileController extends Controller
                     'pyramids' => 'pyramid',
                 ];
 
-                $hasAnyCompletion = false;
-                $hasAnyItemCompletion = false;
-
-                // Check each format type for completion
+                // Check each format type for completion - only tracking is_completed for individual items
                 foreach ($formatMapping as $relation => $formatType) {
                     if ($workout->{$relation} && $workout->{$relation}->isNotEmpty()) {
                         foreach ($workout->{$relation} as $formatItem) {
@@ -774,10 +771,6 @@ class UserMobileController extends Controller
                                 ->where('date', $dateString)
                                 ->exists();
 
-                            if ($isCompleted) {
-                                $hasAnyCompletion = true;
-                            }
-
                             // Check if this specific format item has reps saved
                             $hasReps = DailyWarmup::where('member_id', $member->id)
                                 ->where('workout_manager_id', $workout->id)
@@ -787,10 +780,6 @@ class UserMobileController extends Controller
                                 ->where('date', $dateString)
                                 ->exists();
 
-                            if ($hasReps) {
-                                $hasAnyItemCompletion = true;
-                            }
-
                             // Add completion status to each format item
                             $formatItem->is_completed = $isCompleted ? 1 : 0;
                             $formatItem->has_reps_saved = $hasReps ? 1 : 0;
@@ -798,29 +787,51 @@ class UserMobileController extends Controller
                     }
                 }
 
-                // Fallback: Check by workout_manager_id only (for backward compatibility)
-                if (!$hasAnyCompletion) {
-                    $hasAnyCompletion = DailyWarmup::where('member_id', $member->id)
-                        ->where('workout_manager_id', $workout->id)
-                        ->where('date', $dateString)
-                        ->exists();
-                }
-
-                if (!$hasAnyItemCompletion) {
-                    $hasAnyItemCompletion = DailyWarmup::where('member_id', $member->id)
-                        ->where('workout_manager_id', $workout->id)
-                        ->where('reps', '>', 0)
-                        ->where('date', $dateString)
-                        ->exists();
-                }
-
-                $workout->workout_completed = $hasAnyCompletion ? 1 : 0;
-                $workout->warmup_item_completed = $hasAnyItemCompletion ? 1 : 0;
+                // Note: Only keeping type_completed and is_completed fields as requested
             });
 
             // Group workouts by type
             $groupedWorkouts = $workouts->groupBy(function ($workout) {
                 return $workout->type->name ?? 'Unknown';
+            });
+
+            // Add type-level completion status: type is completed only if ALL format items across ALL workouts in that type are completed
+            $groupedWorkouts = $groupedWorkouts->map(function ($typeWorkouts, $typeName) {
+                $totalFormatItems = 0;
+                $completedFormatItems = 0;
+                
+                // Count all format items and completed items across all workouts in this type
+                $typeWorkouts->each(function ($workout) use (&$totalFormatItems, &$completedFormatItems) {
+                    $formatMapping = [
+                        'rounds' => 'rounds',
+                        'amraps' => 'amrap',
+                        'forTimes' => 'for_time',
+                        'intervals' => 'intervals',
+                        'emoms' => 'emom',
+                        'straights' => 'straight_sets',
+                        'circuits' => 'circuits',
+                        'pyramids' => 'pyramid',
+                    ];
+                    
+                    foreach ($formatMapping as $relation => $formatType) {
+                        if ($workout->{$relation} && $workout->{$relation}->isNotEmpty()) {
+                            foreach ($workout->{$relation} as $formatItem) {
+                                $totalFormatItems++;
+                                if ($formatItem->is_completed == 1) {
+                                    $completedFormatItems++;
+                                }
+                            }
+                        }
+                    }
+                });
+                
+                // Add type completion status to each workout in this type
+                $typeCompletionStatus = ($totalFormatItems > 0 && $completedFormatItems === $totalFormatItems) ? 1 : 0;
+                $typeWorkouts->each(function ($workout) use ($typeCompletionStatus) {
+                    $workout->type_completed = $typeCompletionStatus;
+                });
+                
+                return $typeWorkouts;
             });
 
             return response()->json([


### PR DESCRIPTION
This pull request refactors the workout completion logic in the `getWorkouts` method to simplify how completion status is calculated and reported. The main change is the removal of per-workout completion flags in favor of a new, more accurate type-level completion status: a workout type is only marked completed if all its format items across all workouts are completed. The logic for tracking individual item completion remains, but the fallback and redundant per-workout checks have been removed.

**Workout completion logic improvements:**

* Removed the legacy per-workout completion flags (`workout_completed` and `warmup_item_completed`) and their related fallback checks, focusing only on individual item completion and type-level completion as requested. [[1]](diffhunk://#diff-ab9ea1409321362d5959d454d9c474dfb312442971cccc6f7d329797b647b193L762-R762) [[2]](diffhunk://#diff-ab9ea1409321362d5959d454d9c474dfb312442971cccc6f7d329797b647b193L777-L780) [[3]](diffhunk://#diff-ab9ea1409321362d5959d454d9c474dfb312442971cccc6f7d329797b647b193L790-R836)
* Added new logic to compute and assign a `type_completed` flag for each workout type: this flag is set to 1 only if all format items in all workouts of that type are completed.

**Code simplification:**

* Cleaned up the code by removing unnecessary variables and checks, making the completion logic easier to follow and maintain. [[1]](diffhunk://#diff-ab9ea1409321362d5959d454d9c474dfb312442971cccc6f7d329797b647b193L762-R762) [[2]](diffhunk://#diff-ab9ea1409321362d5959d454d9c474dfb312442971cccc6f7d329797b647b193L777-L780) [[3]](diffhunk://#diff-ab9ea1409321362d5959d454d9c474dfb312442971cccc6f7d329797b647b193L790-R836)