### PR TITLE
Refactor strength daily storage validation and remove unused strength_id

### DIFF
--- a/app/Http/Controllers/MobileController.php
+++ b/app/Http/Controllers/MobileController.php
@@ -513,11 +513,10 @@ class MobileController extends Controller
                     'workout_manager_id' => 'required|integer',
                     'workout_format_type' => 'required|string|in:rounds,amrap,for_time,intervals,emom,straight_sets,circuits,pyramid',
                     'workout_format_id' => 'required|integer',
-                    #'reps' => 'required|integer',
-                    #'weight' => 'nullable|numeric',
-                    #'set_number' => 'required|integer',
-                    'date' => 'required|string',
-                    #'strength_id' => 'required|integer', 
+                    'reps' => 'required|integer',
+                    'set_number' => 'required|integer',
+                    'weight' => 'nullable|numeric',
+                    'date' => 'required|string'
                 ]);
 
                 if ($validator->fails()) {
@@ -536,7 +535,6 @@ class MobileController extends Controller
                 $workoutFormatType = $validatedData['workout_format_type'];
                 $workoutFormatId = $validatedData['workout_format_id'];
                 $workoutManagerId = $validatedData['workout_manager_id'];
-                $strengthId = $validatedData['strength_id'];
 
                 // Check if record exists for this member + workout_manager_id + format checks + set_number
                 $query = DailyStrength::where('member_id', $memberId)
@@ -556,7 +554,6 @@ class MobileController extends Controller
                         'reps' => $validatedData['reps'],
                         'weight' => $weight,
                         'date' => $storedDay,
-                        'strength_id' => $strengthId, // Ensure legacy ID is sync'd
                     ]);
                     $message = 'Strength updated successfully';
                     Log::info('Strength updated', [
@@ -570,7 +567,6 @@ class MobileController extends Controller
                         'workout_manager_id' => $workoutManagerId,
                         'workout_format_type' => $workoutFormatType,
                         'workout_format_id' => $workoutFormatId,
-                        'strength_id' => $strengthId,
                         'reps' => $validatedData['reps'],
                         'weight' => $weight,
                         'set_number' => $setNumber,


### PR DESCRIPTION
This pull request updates the `storestrengthdaily` method in `MobileController.php` to require additional workout data and removes legacy handling for the `strength_id` field. The changes improve data validation and simplify record creation and updating logic by eliminating unused or legacy fields.

Validation improvements:

* Added `reps` and `set_number` as required fields, and `weight` as nullable, in the request validation for workout data.

Legacy field removal:

* Removed all references to the `strength_id` field from validation, variable assignment, and database record creation/updating logic. [[1]](diffhunk://#diff-1d38c9dc68d8a4497797b2b6321e824b2df29caa3c59a4dd037fff1f9a16c3a8L516-R519) [[2]](diffhunk://#diff-1d38c9dc68d8a4497797b2b6321e824b2df29caa3c59a4dd037fff1f9a16c3a8L539) [[3]](diffhunk://#diff-1d38c9dc68d8a4497797b2b6321e824b2df29caa3c59a4dd037fff1f9a16c3a8L559) [[4]](diffhunk://#diff-1d38c9dc68d8a4497797b2b6321e824b2df29caa3c59a4dd037fff1f9a16c3a8L573)