### PR TITLE
Save weightligting workout api update imesha

### DIFF
--- a/app/Http/Controllers/MobileController.php
+++ b/app/Http/Controllers/MobileController.php
@@ -638,11 +638,10 @@ class MobileController extends Controller
                     'workout_manager_id' => 'required|integer',
                     'workout_format_type' => 'required|string|in:rounds,amrap,for_time,intervals,emom,straight_sets,circuits,pyramid',
                     'workout_format_id' => 'required|integer',
-                    #'reps' => 'required|integer',
+                    'reps' => 'required|integer',
                     'weight' => 'nullable|numeric',
-                    #'set_number' => 'required|integer',
+                    'set_number' => 'required|integer',
                     'date' => 'required|string',
-                    #'weightlifting_id' => 'required|integer',
                 ]);
 
                 if ($validator->fails()) {
@@ -661,7 +660,6 @@ class MobileController extends Controller
                 $workoutFormatType = $validatedData['workout_format_type'];
                 $workoutFormatId = $validatedData['workout_format_id'];
                 $workoutManagerId = $validatedData['workout_manager_id'];
-                $weightliftingId = $validatedData['weightlifting_id'];
 
                 // Check if record exists for this member + workout_manager_id + format checks + set_number
                 $query = DailyWeightlifting::where('member_id', $memberId)
@@ -680,8 +678,7 @@ class MobileController extends Controller
                     $dailyWeightlifting->update([
                         'reps' => $validatedData['reps'],
                         'weight' => $weight,
-                        'date' => $storedDay,
-                        'weightlifting_id' => $weightliftingId,
+                        'date' => $storedDay
                     ]);
                     $message = 'Weightlifting updated successfully';
                     Log::info('Weightlifting updated', [
@@ -695,7 +692,6 @@ class MobileController extends Controller
                         'workout_manager_id' => $workoutManagerId,
                         'workout_format_type' => $workoutFormatType,
                         'workout_format_id' => $workoutFormatId,
-                        'weightlifting_id' => $weightliftingId,
                         'reps' => $validatedData['reps'],
                         'weight' => $weight,
                         'set_number' => $setNumber,

--- a/app/Http/Controllers/UserMobileController.php
+++ b/app/Http/Controllers/UserMobileController.php
@@ -8,6 +8,7 @@ use App\Models\DailyConditioning;
 use App\Models\DailyStrength;
 use App\Models\DailyWarmup;
 use App\Models\DailyWeightlifting;
+use App\Models\DailyAccessory;
 use App\Models\MonthlyImage;
 use App\Models\Newprofile;
 use App\Models\Strength;
@@ -747,6 +748,27 @@ class UserMobileController extends Controller
 
             // Check warmup completion status for each workout using polymorphic format tracking
             $workouts->each(function ($workout) use ($member, $dateString) {
+
+            // Decide workout type ONCE per workout
+                $typeName = strtolower($workout->type->name ?? '');
+
+                switch ($typeName) {
+                    case 'strength':
+                        $dailyModel = DailyStrength::class;
+                        break;
+
+                    case 'weightlifting':
+                        $dailyModel = DailyWeightlifting::class;
+                        break;
+
+                    case 'accessory':
+                        $dailyModel = DailyAccessory::class;
+                        break;
+
+                    default:
+                        $dailyModel = DailyWarmup::class;
+                        break;
+                }
                 // Map format relationships to their types
                 $formatMapping = [
                     'rounds' => 'rounds',
@@ -789,25 +811,62 @@ class UserMobileController extends Controller
                             unset($formatItem->has_reps_saved);
 
                         } else {
+                            // Base query
+                            $baseQuery = $dailyModel::where('member_id', $member->id)
+                            ->where('workout_manager_id', $workout->id)
+                            ->where('workout_format_type', $formatType)
+                            ->where('workout_format_id', $formatItem->id)
+                            ->where('date', $dateString);
 
-                            // NORMAL FORMATS (rounds, emom, etc)
-                            $isCompleted = DailyWarmup::where('member_id', $member->id)
-                                ->where('workout_manager_id', $workout->id)
-                                ->where('workout_format_type', $formatType)
-                                ->where('workout_format_id', $formatItem->id)
-                                ->where('date', $dateString)
-                                ->exists();
+                        /*
+                        |--------------------------------------------------------------------------
+                        | STRENGTH + WEIGHTLIFTING 
+                        |--------------------------------------------------------------------------
+                        */
+                        if (in_array($typeName, ['strength', 'weightlifting', 'accessory'])
+                            && $formatItem->sets
+                            && $formatItem->sets->isNotEmpty()) {
 
-                            $hasReps = DailyWarmup::where('member_id', $member->id)
-                                ->where('workout_manager_id', $workout->id)
-                                ->where('workout_format_type', $formatType)
-                                ->where('workout_format_id', $formatItem->id)
+                            $totalSets = $formatItem->sets->count();
+                            $completedSets = 0;
+
+                            foreach ($formatItem->sets as $set) {
+
+                                $setCompleted = (clone $baseQuery)
+                                    ->where('set_number', $set->set_number)
+                                    ->exists();
+
+                                if ($setCompleted) {
+                                    $completedSets++;
+                                }
+
+                                $set->is_completed = $setCompleted ? 1 : 0;
+                            }
+
+                            // Format completed only if ALL sets completed
+                            $formatItem->is_completed =
+                                ($completedSets === $totalSets) ? 1 : 0;
+
+                            unset($formatItem->has_reps_saved);
+                        }
+
+                        /*
+                        |--------------------------------------------------------------------------
+                        | WARMUP + OTHERS 
+                        |--------------------------------------------------------------------------
+                        */
+                        else {
+
+                            $isCompleted = $baseQuery->exists();
+
+                            $hasReps = (clone $baseQuery)
                                 ->where('reps', '>', 0)
-                                ->where('date', $dateString)
                                 ->exists();
 
                             $formatItem->is_completed = $isCompleted ? 1 : 0;
                             $formatItem->has_reps_saved = $hasReps ? 1 : 0;
+                        }
+
                         }
                     }
                 }

--- a/app/Models/DailyAccessory.php
+++ b/app/Models/DailyAccessory.php
@@ -15,6 +15,7 @@ class DailyAccessory extends Model
         'workout_manager_id',
         'workout_format_type',
         'workout_format_id',
+        'set_number',
         'reps',
         'weight',
         'date',

--- a/database/migrations/2026_02_18_074345_add_set_number_to_daily_accessory_table.php
+++ b/database/migrations/2026_02_18_074345_add_set_number_to_daily_accessory_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('daily_accessory', function (Blueprint $table) {
+            $table->integer('set_number')->nullable()->after('workout_format_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('daily_accessory', function (Blueprint $table) {
+            $table->dropColumn('set_number');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -43,6 +43,7 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::post('/save-strength-workout',  [MobileController::class, 'storestrengthdaily']);
     Route::post('/save-weightligting-workout',  [MobileController::class, 'storeweightliftingdaily']);
     Route::post('/save-conditioning-workout',  [MobileController::class, 'storeconditioningdaily']);
+    Route::post('/save-accessory-workout',  [MobileController::class, 'storeaccessorydaily']);
 
     //profile
     Route::get('profile', [UserMobileController::class, 'viewprofile'])->name('userprofile');


### PR DESCRIPTION
This pull request introduces support for tracking sets in accessory workouts, improves the workout completion logic to handle multiple workout types more accurately, and makes related schema and API updates. The most important changes are summarized below:

**Accessory Workout Set Tracking**

* Added a new migration to include a `set_number` column in the `daily_accessory` table, allowing individual sets within accessory workouts to be tracked.
* Updated the `DailyAccessory` model to include `set_number` in its fillable attributes, enabling mass assignment for this field.

**Workout Completion Logic Improvements**

* Enhanced the `getWorkouts` method in `UserMobileController` to determine the correct daily model (`DailyStrength`, `DailyWeightlifting`, `DailyAccessory`, or `DailyWarmup`) based on the workout type, and to check set completion status for strength, weightlifting, and accessory workouts. [[1]](diffhunk://#diff-ab9ea1409321362d5959d454d9c474dfb312442971cccc6f7d329797b647b193R751-R771) [[2]](diffhunk://#diff-ab9ea1409321362d5959d454d9c474dfb312442971cccc6f7d329797b647b193L792-R870)
* Updated the logic to check completion of all sets for these workout types, marking the format as completed only if all sets are done.

**API and Controller Adjustments**

* Registered a new API route for saving accessory workout data, linking it to the `storeaccessorydaily` method in `MobileController`.
* Included the `DailyAccessory` model in the `UserMobileController` imports to support the new functionality.

**Validation and Data Handling Fixes**

* Modified validation in `storeweightliftingdaily` to require `reps` and `set_number` fields, ensuring proper data integrity for weightlifting entries.
* Cleaned up unused or commented-out code related to `weightlifting_id` in the same method. [[1]](diffhunk://#diff-1d38c9dc68d8a4497797b2b6321e824b2df29caa3c59a4dd037fff1f9a16c3a8L664) [[2]](diffhunk://#diff-1d38c9dc68d8a4497797b2b6321e824b2df29caa3c59a4dd037fff1f9a16c3a8L683-R681) [[3]](diffhunk://#diff-1d38c9dc68d8a4497797b2b6321e824b2df29caa3c59a4dd037fff1f9a16c3a8L698)